### PR TITLE
Selected menu

### DIFF
--- a/src/ESUGApp-Component/ERItemNav.class.st
+++ b/src/ESUGApp-Component/ERItemNav.class.st
@@ -30,9 +30,24 @@ ERItemNav >> callback: anObject [
 	callback := anObject
 ]
 
+{ #category : #action }
+ERItemNav >> evaluateCallBackBlock [
+	callback value value.
+]
+
+{ #category : #action }
+ERItemNav >> iAmClicked [
+	self session activeMenu:  label,'-option'.
+]
+
 { #category : #accessing }
 ERItemNav >> icon: anObject [
 	icon := anObject
+]
+
+{ #category : #accessing }
+ERItemNav >> isCurrentlyActive [ 
+	^ self session activeMenu =  (label,'-option').
 ]
 
 { #category : #accessing }
@@ -44,7 +59,8 @@ ERItemNav >> label: anObject [
 ERItemNav >> renderContentOn: html [
 	html mdlNavigationLink
 		id: label,'-option';
-		callback: callback;
+		callback: [self getCallback ];
+		class: 'active-menu-option' if: (self isCurrentlyActive );
 		with: [ 
 			html mdlIcon
 				class: 'mdl-color-text--white';

--- a/src/ESUGApp-Component/ERItemNav.class.st
+++ b/src/ESUGApp-Component/ERItemNav.class.st
@@ -36,6 +36,14 @@ ERItemNav >> evaluateCallBackBlock [
 ]
 
 { #category : #action }
+ERItemNav >> getCallback [ 
+	self iAmClicked.
+	self evaluateCallBackBlock.
+	 
+	
+]
+
+{ #category : #action }
 ERItemNav >> iAmClicked [
 	self session activeMenu:  label,'-option'.
 ]

--- a/src/ESUGApp-Core/ERSession.class.st
+++ b/src/ESUGApp-Core/ERSession.class.st
@@ -56,6 +56,11 @@ ERSession >> logout [
 	self unregister
 ]
 
+{ #category : #actions }
+ERSession >> setDefaultMenu [
+	self activeMenu:self defaultMenu .
+]
+
 { #category : #updating }
 ERSession >> updateRoot: anHtmlRoot [
 	super updateRoot: anHtmlRoot.

--- a/src/ESUGApp-Core/ERSession.class.st
+++ b/src/ESUGApp-Core/ERSession.class.st
@@ -52,7 +52,7 @@ ERSession >> login: aUser [
 { #category : #actions }
 ERSession >> logout [
 	self user: nil.
-	self activeMenu: nil.
+	self activeMenu: ''.
 	self unregister
 ]
 

--- a/src/ESUGApp-Core/ERSession.class.st
+++ b/src/ESUGApp-Core/ERSession.class.st
@@ -9,10 +9,23 @@ Class {
 	#superclass : #WASession,
 	#instVars : [
 		'user',
-		'account'
+		'account',
+		'activeMenuId'
 	],
 	#category : #'ESUGApp-Core'
 }
+
+{ #category : #accessing }
+ERSession >> activeMenu [
+	"Get the id of current selected menu item in navbar"
+	^ activeMenuId .
+]
+
+{ #category : #accessing }
+ERSession >> activeMenu:id [
+	"Set the id of current selected menu item in navbar"
+	 activeMenuId :=id.
+]
 
 { #category : #intialization }
 ERSession >> initialize [
@@ -33,6 +46,7 @@ ERSession >> login: aUser [
 { #category : #actions }
 ERSession >> logout [
 	self user: nil.
+	self activeMenu: nil.
 	self unregister
 ]
 

--- a/src/ESUGApp-Core/ERSession.class.st
+++ b/src/ESUGApp-Core/ERSession.class.st
@@ -27,9 +27,15 @@ ERSession >> activeMenu:id [
 	 activeMenuId :=id.
 ]
 
+{ #category : #accessing }
+ERSession >> defaultMenu [
+	^ 'Home-option'.
+]
+
 { #category : #intialization }
 ERSession >> initialize [
 	super initialize.
+	self setDefaultMenu.
 ]
 
 { #category : #actions }

--- a/src/ESUGApp-Library/ERLibrary.class.st
+++ b/src/ESUGApp-Library/ERLibrary.class.st
@@ -159,7 +159,12 @@ html, body {
   background-color: #0b7bfc;
   color: white;
 }
-
+.active-menu-option{
+  background-color: #0b7bfc;
+  border-left: 8px white solid;
+  font-weight:bold;
+  color: white;
+}
 .demo-navigation .mdl-navigation__link .material-icons {
   font-size: 24px;
   color: white;

--- a/src/ESUGApp-View/ERLoggedPage.class.st
+++ b/src/ESUGApp-View/ERLoggedPage.class.st
@@ -82,6 +82,7 @@ ERLoggedPage >> initialize [
 	(ERHomeView
 				withContent: content
 				withController: pageController).
+	self session activeMenu:'Home-option'.
 	self initializeNabvar.
 ]
 

--- a/src/ESUGApp-View/ERLoggedPage.class.st
+++ b/src/ESUGApp-View/ERLoggedPage.class.st
@@ -82,7 +82,7 @@ ERLoggedPage >> initialize [
 	(ERHomeView
 				withContent: content
 				withController: pageController).
-	self session activeMenu:'Home-option'.
+	self session setDefaultMenu.
 	self initializeNabvar.
 ]
 


### PR DESCRIPTION
Add a dynamic styling to differentiate selected menu item from the others. 
Currently, there is no sign showing which menu item is associated with the current view rendered. 
 
Since tests are not OK yet, the PR might require more time to be evaluated and eventually  merged. 


![selected](https://user-images.githubusercontent.com/36144543/197033038-d1fb97cf-d538-4f45-b440-4997319dae1c.png)


 

